### PR TITLE
Fixes bug where GitHub ID column was hardcoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function filterContributorByTime(idObject, dates) {
     }
 }
 function fetchUserDataAndAddToCSV(row, dates) {
-    let url = `https://api.github.com/users/${row[1]}/events`;
+    let url = `https://api.github.com/users/${row[githubIdColumnNumber]}/events`;
     fetchPageOfDataAndFilter(url).then(importantEvents => {
         let idObject = {};
         createIdObjects(row, idObject, importantEvents);


### PR DESCRIPTION
GitHUB ID column is specified in the .env file and loaded into a variable, but was incorrectly hardcoded.