### PR TITLE
feat(tests): add jest tests for helper functions

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,0 +1,6 @@
+process.env.GITHUB_TOKEN = 'mock_token';
+process.env.TIMEZONE = 'America/Los_Angeles';
+process.env.CSV_COLUMN_NUMBER_FOR_GITHUB_ID = '0';
+process.env.CSV_COLUMN_NUMBER_FOR_ALTERNATE_ID = '1';
+process.env.GITHUB_IMPORTANT_EVENTS =
+    'CommitCommentEvent,IssueCommentEvent,IssuesEvent,PullRequestEvent,PullRequestReviewEvent,PullRequestReviewCommentEvent';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-gettext": "^1.1.0",
     "moment-range": "^4.0.2",
     "moment-timezone": "^0.5.31",
+    "nock": "^13.0.4",
     "node-fetch": "^2.6.1",
     "parse-csv": "^0.2.0",
     "parse-link-header": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
       "!**/node_modules/**",
       "!**/coverage/**"
     ],
-    "coverageDirectory": "<rootDir>/coverage"
+    "coverageDirectory": "<rootDir>/coverage",
+    "setupFiles": [
+      "<rootDir>/.jest/setEnvVars.js"
+    ]
   }
 }


### PR DESCRIPTION
Issue: #13

Added jest tests for `fetchPageOfDataAndFilter` and `createIdObject` function.

Added `nock` as a developer dependency for HTTP server mocking purposes.