### PR TITLE
Do not ignore CSVsToParse/.gitignore

### DIFF
--- a/CSVsToParse/.gitignore
+++ b/CSVsToParse/.gitignore
@@ -1,2 +1,5 @@
 # This wildcard filter pattern will ignore all files in this directory in order to prevent accidental commits of sensitive information.
 *
+
+# Except this file
+!.gitignore


### PR DESCRIPTION
I noticed the `CSVsToParse/.gitignore` is also ignored (due to the ignore being `*`). As a best practice, you should never have files checked into version control that are ignored. So this just adds an exclusion for the gitignore file itself.